### PR TITLE
Make headers conform more closely to Package.el spec

### DIFF
--- a/orglue-publish.el
+++ b/orglue-publish.el
@@ -1,9 +1,14 @@
-;;; orglue-publish.el -- more functionality to org-mode publish.
-;;
+;;; orglue-publish.el --- more functionality to org-mode publish.
+
+;; Copyright (C) 2012-2013 Yoshinari Nomura.
+;; All rights reserved.
+
 ;; Author:  Yoshinari Nomura <nom@quickhack.net>
 ;; Created: 2012-08-28
+;; Version: 1.0
+;; Keywords: org
 ;;
-;;; Commentay:
+;;; Commentary:
 ;;
 ;;; Code:
 ;;
@@ -138,9 +143,6 @@ This hook is useful for settingup org-publish-project-alist before ``org-publish
 (provide 'orglue-publish)
 
 ;;; Copyright Notice:
-
-;; Copyright (C) 2012-2013 Yoshinari Nomura.
-;; All rights reserved.
 
 ;; Redistribution and use in source and binary forms, with or without
 ;; modification, are permitted provided that the following conditions

--- a/orglue.el
+++ b/orglue.el
@@ -1,9 +1,15 @@
-;;; orglue.el -- more functionality to org-mode.
-;;
+;;; orglue.el --- more functionality to org-mode.
+
+;; Copyright (C) 2011, 2012 Yoshinari Nomura.
+;; All rights reserved.
+
 ;; Author:  Yoshinari Nomura <nom@quickhack.net>
 ;; Created: 2012-08-28
-;;
-;;; Commentay:
+;; Version: 1.0
+;; Package-Requires: ((epic "0.1") (org-mac-link-grabber "1.0.1"))
+;; Keywords: org
+
+;;; Commentary:
 ;;
 ;;; Code:
 ;;
@@ -303,10 +309,7 @@ indent to fit the current outline level. Otherwise, do ``indent-rigidly''."
 (provide 'orglue)
 
 ;;; Copyright Notice:
-
-;; Copyright (C) 2011, 2012 Yoshinari Nomura.
-;; All rights reserved.
-
+;;
 ;; Redistribution and use in source and binary forms, with or without
 ;; modification, are permitted provided that the following conditions
 ;; are met:


### PR DESCRIPTION
I wanted to give org-octopress a try and was creating recipes for melpa, when they failed. These updates should fix it.

See https://github.com/milkypostman/melpa/pull/594 for more info
